### PR TITLE
feat: ループエンジニアリング取り込み（ADR-008〜013 + Inner Loop親スキル3本）

### DIFF
--- a/.claude/skills/auto-bug/SKILL.md
+++ b/.claude/skills/auto-bug/SKILL.md
@@ -1,0 +1,167 @@
+---
+user-invocable: true
+description: "bug の自律修正ループ。bug-investigate → bug-propose → bug-fix → テスト → basic-review → deep-review → PR → ai-merged-unreviewed ラベル → task→sprint 自律マージ までを1コマンドで完結。Inner Loop の親スキル。"
+---
+
+# [ループ] 自律バグ修正 `/auto-bug`
+
+> Loop Engineering の Inner Loop 親スキル（bug 専用）。既存スキル（bug-investigate / bug-propose / bug-fix / basic-review / deep-review）を**連鎖呼び出し**して 1 bug を自律で完了まで運ぶ。
+>
+> 設計根拠: `meta/adr-lite.md` の **ADR-008 / ADR-009 / ADR-010**
+>
+> 関連: `/auto-task` は task 実行中に bug 検知すると bug-* 連鎖を内部発動する（こちらは bug 単独処理の入口）
+
+## 入力: $ARGUMENTS
+- Issue番号（例: `#123` または `123`）
+- 省略時: ラベル `bug` がついた Issue から選択
+
+---
+
+## 🎯 目的
+- bug の **調査〜修正〜マージまで自律で走らせる**
+- 修正案が複数ある場合は **提案 → 効果検証 → 採用** の流れで進める
+- 効果なしならロールバックして次案へ
+- 中断時は **`history/loop-state.md`** に記録
+
+---
+
+## 前提（必ず確認）
+
+- 対象 Issue に `bug` ラベルが付いているか、または bug-new で起票済みであること
+- `feature_fix/*` ブランチで動く（`.claude/rules/git.md` 参照）
+- 課金が発生しうる操作は事前にユーザー確認（`/auto-task` と同じ方針）
+
+---
+
+## 実行手順
+
+### 0. ループ状態ファイルの初期化
+
+`history/loop-state.md` を以下で開始:
+
+```markdown
+## YYYY-MM-DD HH:MM /auto-bug #<issue-number>
+- branch: <現在ブランチ>
+- status: in_progress
+- steps:
+  - [ ] bug-investigate
+  - [ ] bug-propose
+  - [ ] bug-fix (恒久対応・効果検証)
+  - [ ] local-checks (lint/typecheck/test)
+  - [ ] basic-review
+  - [ ] deep-review
+  - [ ] pr-create
+  - [ ] label-attach
+  - [ ] auto-merge
+- last_action: ループ開始
+```
+
+各ステップ完了時に `[x]` 更新と `last_action` 書き換え。
+
+---
+
+### 1. 調査（bug-investigate）
+
+- `bug-investigate` の手順に従って原因を絞り込む
+- 仮説と再現手順を Issue コメントに追記
+
+---
+
+### 2. 修正案列挙（bug-propose）
+
+- `bug-propose` の手順で修正策を列挙し、Issue コメントに追記
+- 恒久対応のみ（暫定対応はスキップまたは恒久案に置換）
+
+---
+
+### 3. 修正実行＋効果検証（bug-fix）
+
+- `bug-fix` の手順で**修正案の上から順に**実施
+- 各修正後に**ローカル lint / typecheck / test** で効果検証
+- **効果なし**: 修正前へロールバック → 次案へ
+- **効果あり**: 確定してステップ4へ
+- 全案を試して直らない場合:
+  - `history/loop-state.md` に `status: blocked_by_bug` を記録
+  - 試行内容と新たな仮説をユーザーへ報告して終了
+
+---
+
+### 4. ローカル検証（最終確認）
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+```
+
+すべて通ることを確認。失敗したらステップ3に戻る（最大3周）。
+
+---
+
+### 5. basic-review 反復
+
+`/auto-task` のステップ4と同じ手順（致命指摘0まで、最大5周）。
+
+---
+
+### 6. deep-review 反復
+
+`/auto-task` のステップ5と同じ手順（全指摘0まで、最大3周）。
+
+---
+
+### 7. PR 作成
+
+- `gh pr create` で `feature_fix/* → sprint/*` の PR を作成
+- 本文には:
+  - Closes #<issue-number>
+  - 採用した修正案（複数試した場合は経緯）
+  - 試した順序と効果の有無
+  - ローカル検証結果
+- target ブランチは適切な sprint ブランチ（`.claude/rules/git.md` 参照）
+
+---
+
+### 8. ラベル付与・自律マージ
+
+`/auto-task` のステップ7-8と同じ:
+- `ai-merged-unreviewed` ラベルを付与
+- `feature_fix/* → sprint/*` を `gh pr merge --squash --delete-branch`
+- **sprint → main は絶対に自律マージしない**
+
+---
+
+## 課金前停止ポイント
+
+`/auto-task` と同じ（新規パッケージ・リモートデプロイ・有料外部 API・有料 CI）。
+
+---
+
+## 中断・再開
+
+`/auto-task` と同じ仕組み。`history/loop-state.md` の `last_action` から再開判定。
+
+---
+
+## やってはいけない
+
+- `bug` Issue として起票されていない問題に対していきなり `/auto-bug` を起動
+  - その場合は先に `bug-new` で起票
+- 修正案を試さずにいきなり「直らない」と諦める
+- 効果検証なしで複数案を同時にコミット
+- ロールバックせず無関係な修正を積み上げる
+- sprint → main の自律マージ
+
+---
+
+## `/auto-task` との関係
+
+- `/auto-task` は **task 実装中に bug を検知**したら bug-* スキル**連鎖を内部発動**する（コマンドとしての `/auto-bug` は呼ばない）
+- `/auto-bug` は **bug が分かっている状態で人間が単独起動**する入口
+- どちらも同じ既存スキル群（bug-investigate / bug-propose / bug-fix / review 系）を呼ぶ → 動作はほぼ同じ
+
+---
+
+## 自己評価
+- **成功自信度**: (1-10)
+- **一言理由**: {何案目で直ったか、ロールバックの回数、レビュー反復回数を踏まえて記載}

--- a/.claude/skills/auto-bug/SKILL.md
+++ b/.claude/skills/auto-bug/SKILL.md
@@ -112,13 +112,16 @@ npm test
 
 ### 7. PR 作成
 
-- `gh pr create` で `feature_fix/* → sprint/*` の PR を作成
+- `gh pr create` で **適切なブランチ → sprint/*** の PR を作成
+  - スプリント統合後に見つかった bug → `feature_fix/* → sprint/*`
+  - task 実装中に派生した bug → `task/* → sprint/*`
+  - 判断基準は `.claude/rules/git.md` 参照
 - 本文には:
   - Closes #<issue-number>
   - 採用した修正案（複数試した場合は経緯）
   - 試した順序と効果の有無
   - ローカル検証結果
-- target ブランチは適切な sprint ブランチ（`.claude/rules/git.md` 参照）
+- target ブランチは適切な sprint ブランチ
 
 ---
 

--- a/.claude/skills/auto-task/SKILL.md
+++ b/.claude/skills/auto-task/SKILL.md
@@ -1,0 +1,196 @@
+---
+user-invocable: true
+description: "task の自律実装ループ。task-run → テスト → bug 検知時 bug-* 連鎖 → basic-review → deep-review → PR → ai-merged-unreviewed ラベル → task→sprint 自律マージ までを1コマンドで完結。Inner Loop の親スキル。"
+---
+
+# [ループ] 自律タスク実装 `/auto-task`
+
+> Loop Engineering の Inner Loop 親スキル。既存スキル（task-run / bug-* / basic-review / deep-review）を**連鎖呼び出し**して 1 task を自律で完了まで運ぶ。スキル本体は触らない（Harness 層不可侵）。
+>
+> 設計根拠: `meta/adr-lite.md` の **ADR-008 / ADR-009 / ADR-010**
+
+## 入力: $ARGUMENTS
+- Issue番号（例: `#123` または `123`）
+- 省略時: 実行可能な Issue を `task-run` 側で選択
+
+---
+
+## 🎯 目的
+- task の **実装〜マージまで自律で走らせる**
+- 失敗・bug 検知時は **bug-* スキル連鎖** で自己修復
+- レビュー指摘は **収束まで反復**
+- 中断時は **`history/loop-state.md`** に記録、session-end が拾う
+
+---
+
+## 前提（必ず確認）
+
+- このスキルは **`task/*` ブランチ上で動く前提**。`sprint/*` 直下や `main` での起動は中止
+- ローカル lint / typecheck / test が**通る状態をゴール**にする（通らないまま PR は出さない）
+- 課金が発生しうる操作（新規パッケージインストール、リモートデプロイ、外部 API 課金）は**事前にユーザーへ確認**して止まる
+- usage 切れは Claude が自動停止に任せる（明示検知不要）
+
+---
+
+## 実行手順
+
+### 0. ループ状態ファイルの初期化
+
+`history/loop-state.md` を以下で開始（既存なら追記）:
+
+```markdown
+## YYYY-MM-DD HH:MM /auto-task #<issue-number>
+- branch: <現在ブランチ>
+- status: in_progress
+- steps:
+  - [ ] task-run
+  - [ ] local-checks (lint/typecheck/test)
+  - [ ] basic-review (致命指摘0まで)
+  - [ ] deep-review (全指摘0まで)
+  - [ ] pr-create
+  - [ ] label-attach (ai-merged-unreviewed)
+  - [ ] auto-merge (task→sprint)
+- last_action: ループ開始
+```
+
+**各ステップ完了時に該当行を `[x]` に更新し、`last_action` を書き換える**。これが ADR-012 の中断時復帰の鍵。
+
+---
+
+### 1. 実装（task-run スキル連鎖）
+
+- `task-run` の手順に従って `$ARGUMENTS` のIssueを実装
+- 完了したら **コミット**（task-run 側で適切に分割）
+
+> `task-run` の中身は触らない。ここではスキルを呼び出すだけ。
+
+---
+
+### 2. ローカル検証（lint / typecheck / test）
+
+順に実行:
+
+```bash
+# プロジェクトの package.json / pyproject.toml 等を確認して適切なコマンドを選ぶ
+npm run lint     # or eslint . / ruff check . など
+npm run typecheck # or tsc --noEmit / mypy . など
+npm test         # or pytest など
+```
+
+**判定**:
+- すべて成功 → ステップ3へ
+- 失敗 → **bug-* スキル連鎖発動**（次セクション）
+
+---
+
+### 3. bug 検知時のフォールバック（bug-* スキル連鎖）
+
+ローカル検証で失敗を検知した、または実装途中で挙動異常を見つけた場合:
+
+1. **bug-investigate** スキルで原因調査（Issue 起票はスキップ可、ローカルメモで進める）
+2. **bug-propose** で修正案を列挙
+3. **bug-fix** で恒久対応を実施
+4. ステップ2のローカル検証を**再実行**
+5. 通るまで（最大3周）反復。**4周目に入る場合は中断してユーザー確認**:
+   - `history/loop-state.md` に `status: blocked_by_bug` を記録
+   - 「3周試みたが修正できない。原因仮説と試行内容を提示するので方針を確認したい」とユーザーへ報告して終了
+
+> bug-* スキル本体は触らない。ここでは連鎖呼び出しのみ。
+
+---
+
+### 4. basic-review 反復（致命指摘0まで）
+
+1. `basic-review` 実行
+2. **致命指摘**（typo・命名・フォーマット等の表面的ミスのうち、修正必須のもの）がある:
+   - 指摘を反映 → コミット → ステップ1（basic-review 再実行）
+3. 致命指摘0 → 次へ
+4. **最大反復回数**: 5 周。超えたら中断してユーザー確認
+
+---
+
+### 5. deep-review 反復（全指摘0まで）
+
+1. `deep-review` 実行
+2. 全指摘を反映 → コミット → 1 に戻る
+3. 全指摘0 → 次へ
+4. **最大反復回数**: 3 周。超えたら中断してユーザー確認
+
+---
+
+### 6. PR 作成
+
+- `gh pr create` で `task/* → sprint/*` の PR を作成
+- 本文には:
+  - Closes #<issue-number>
+  - 主な変更点（コミット履歴から抽出）
+  - bug-* 連鎖を発動していた場合は経緯を簡潔に
+  - ローカル検証結果（lint/typecheck/test の成功）
+- target ブランチは現在 task ブランチが切られた sprint ブランチ（`.claude/rules/git.md` 参照）
+
+---
+
+### 7. ラベル付与 `ai-merged-unreviewed`
+
+```bash
+# ラベルが存在しない場合は初回作成
+gh label create ai-merged-unreviewed \
+  --description "AI が自律マージした PR。人間目視レビュー前" \
+  --color "FF9F40" 2>/dev/null || true
+
+# PR にラベル付与
+gh pr edit <PR-NUMBER> --add-label ai-merged-unreviewed
+```
+
+---
+
+### 8. 自律マージ（task → sprint）
+
+**重要**: マージ対象は **task → sprint のみ**。sprint → main へは絶対に自律マージしない。
+
+```bash
+gh pr merge <PR-NUMBER> --squash --delete-branch
+```
+
+マージ完了後:
+- `history/loop-state.md` の `status: completed` に更新
+- ユーザーへ「`gh pr list --label ai-merged-unreviewed` で人間レビュー待ちPR一覧」を案内
+- レビュー済みなら `gh pr edit <PR> --remove-label ai-merged-unreviewed` で外す運用
+
+---
+
+## 課金前停止ポイント（実行中の確認プロンプト）
+
+以下に該当する操作の**直前にユーザーへ確認**して止まる:
+
+- 新規パッケージインストール（特に従量課金 SaaS を絡める場合）
+- リモートデプロイ
+- OpenAI/Anthropic 以外の外部 API 課金
+- GitHub Actions の有料ランナー起動
+
+**確認なしで OK**: gh CLI / git / lint / typecheck / test / ローカルツール全般
+
+---
+
+## 中断・再開
+
+- API エラーや usage 切れで停止した場合、`history/loop-state.md` の最終 `last_action` から再開する
+- 次回 session-start で journal を読めば中断箇所が分かる（ADR-012）
+- 手動で再開する場合は `/auto-task <同じissue>` を再起動。状態ファイルから続きを判定する
+
+---
+
+## やってはいけない
+
+- `task/*` 以外のブランチで起動（特に main、sprint/* 直下）
+- sprint → main の自律マージ
+- bug-* 連鎖を 3 周以上回しても直らない時に押し切ってマージ
+- 課金発生ポイントの確認をスキップ
+- ローカル検証が落ちたまま PR 作成
+- `history/loop-state.md` の更新を怠る
+
+---
+
+## 自己評価
+- **成功自信度**: (1-10)
+- **一言理由**: {ループの収束過程で詰まりがなかったか、bug-* 連鎖の発動回数、レビュー反復回数を踏まえて記載}

--- a/.claude/skills/auto-task/SKILL.md
+++ b/.claude/skills/auto-task/SKILL.md
@@ -103,7 +103,7 @@ npm test         # or pytest など
 
 1. `basic-review` 実行
 2. **致命指摘**（typo・命名・フォーマット等の表面的ミスのうち、修正必須のもの）がある:
-   - 指摘を反映 → コミット → ステップ1（basic-review 再実行）
+   - 指摘を反映 → コミット → 1. に戻る
 3. 致命指摘0 → 次へ
 4. **最大反復回数**: 5 周。超えたら中断してユーザー確認
 
@@ -165,7 +165,7 @@ gh pr merge <PR-NUMBER> --squash --delete-branch
 
 - 新規パッケージインストール（特に従量課金 SaaS を絡める場合）
 - リモートデプロイ
-- OpenAI/Anthropic 以外の外部 API 課金
+- 任意の従量課金 SaaS への新規呼び出し（Claude API 以外の外部 API）
 - GitHub Actions の有料ランナー起動
 
 **確認なしで OK**: gh CLI / git / lint / typecheck / test / ローカルツール全般

--- a/.claude/skills/build-context-site/SKILL.md
+++ b/.claude/skills/build-context-site/SKILL.md
@@ -1,0 +1,193 @@
+---
+user-invocable: true
+description: "doc/input + doc/generated + meta/adr-lite + history の最新を統合し、ローカル閲覧用の HTML サイト（要件・設計・ADR・図を横断）を生成する。「ここ見れば全コンテキスト分かる」プロジェクト現状サイト。"
+---
+
+# [ループ] 全コンテキスト HTML サイト `/build-context-site`
+
+> プロジェクトの**全ドキュメントを横断**できるローカル HTML サイトを生成する。要件・設計・ADR・履歴をブラウザ1つで把握できる場を作る。
+>
+> 設計根拠: `meta/adr-lite.md` の **ADR-008 / ADR-011 / ADR-013**
+
+## 入力: $ARGUMENTS
+- 省略時: 既定の対象範囲（後述）で全部生成
+- 範囲指定する場合: `design` / `requirements` / `adr` / `all` のいずれか
+
+---
+
+## 🎯 目的
+- 散在する Markdown ドキュメント（`doc/input/*`, `doc/generated/*`, `meta/adr-lite.md`）を**一画面で横断できる HTML サイト**にする
+- 図（drawio / mermaid）を**埋め込み**で構造を可視化
+- 引き継ぎ・確認コストを下げる（人間も AI も同じサイトを参照可能）
+- ローカルサーバで閲覧（外部公開はしない）
+
+---
+
+## 前提（必ず確認）
+
+- `reviewable-html-workbench` プラグインが install 済みであること
+  - 未 install の場合は手動でユーザーへ案内（後述）
+- 対象ドキュメントが存在すること（空なら警告して生成スキップ）
+- 出力先 `doc/generated/context-site/` の書き込み権限
+
+### reviewable-html-workbench の install 確認
+
+```bash
+claude plugin list | grep -i reviewable-html-workbench || echo "未install"
+```
+
+未 install の場合、以下をユーザーへ案内して中断:
+
+```
+reviewable-html-workbench プラグインが必要です。以下を実行してください:
+
+claude plugin marketplace add u-ichi/reviewable-html-workbench
+claude plugin install reviewable-html-workbench
+
+install 後に /build-context-site を再実行してください。
+```
+
+---
+
+## 対象ドキュメント
+
+### 既定（`all` または引数省略時）
+| カテゴリ | パス | 用途 |
+|---|---|---|
+| 要件 | `doc/input/rdd.md`, `doc/input/*.md` | プロジェクトのRDD・追加要件 |
+| デザイン | `doc/input/design/**/*.md`, `doc/input/design/**/*.json` | デザイン SSOT・モック |
+| 生成物 | `doc/generated/**/*.md` | マニュアル・自動生成ドキュメント |
+| ADR | `meta/adr-lite.md` | 設計決定ログ |
+| 履歴（任意） | `history/journal.md` の最新7日分 | ローカル閲覧用、配布物には含まない |
+
+### 引数による絞り込み
+- `requirements`: 要件のみ
+- `design`: デザインのみ
+- `adr`: ADR のみ
+- `all`: 全部（既定）
+
+---
+
+## 実行手順
+
+### 1. 対象ドキュメントの収集
+
+```bash
+# 例: all の場合
+find doc/input doc/generated -type f \( -name "*.md" -o -name "*.json" \) 2>/dev/null
+cat meta/adr-lite.md
+# history は最新7日分のみ
+```
+
+### 2. 図の埋め込み準備（MCP）
+
+ドキュメント中に以下のパターンがあれば、対応する MCP を呼び出して図を生成:
+
+- **mermaid コードブロック** ` ```mermaid ... ``` `
+  - そのままレンダリング可能（reviewable-html-workbench 側の `visual-html-renderer` が対応）
+- **drawio リファレンス** `<!-- drawio:path/to/file.drawio -->`
+  - MCP の drawio ツール（`mcp__drawio__open_drawio_xml`）で XML をレンダリング
+- **構造説明テキスト**（システム構成・データフロー等）
+  - 必要なら mermaid を新規生成して埋め込む（既存ドキュメントは改変しない、サイト側の overlay として）
+
+> ⚠️ **既存ドキュメントは絶対に書き換えない**。サイト生成時の overlay として図を足すだけ。
+
+### 3. HTML 生成（reviewable-html-workbench の `render`）
+
+```bash
+# サイトのモデル定義（reviewable-html-workbench の build-model）
+# 詳細は plugin の skill (reviewable-design-doc / visual-html-renderer) の指示に従う
+
+python3 -m scripts.html_review_workbench.cli build-model \
+  --input-dir doc/ \
+  --input-file meta/adr-lite.md \
+  --output doc/generated/context-site/model.json
+
+python3 -m scripts.html_review_workbench.cli render \
+  --model doc/generated/context-site/model.json \
+  --output-dir doc/generated/context-site/ \
+  --title "<プロジェクト名> プロジェクト全コンテキスト"
+```
+
+> 実際のコマンド名・引数は reviewable-html-workbench の最新版に合わせる。バージョン不整合時はプラグインの README を参照。
+
+### 4. ナビゲーション生成
+
+`doc/generated/context-site/index.html` を起点に、以下が見渡せる構造:
+
+- 📋 要件（rdd.md, 追加要件）
+- 🎨 デザイン（SSOT, モック）
+- 🏗 ADR（設計決定の歴史）
+- 📚 生成物（マニュアル等）
+- 📔 履歴（journal の最新分、ローカル閲覧時のみ）
+
+### 5. プレビューサーバ起動
+
+```bash
+# reviewable-html-workbench のプレビュー機能
+python3 -m scripts.html_review_workbench.cli preview \
+  --dir doc/generated/context-site/
+
+# または簡易サーバ（フォールバック）
+cd doc/generated/context-site/ && python3 -m http.server 8765
+```
+
+起動 URL をユーザーへ案内（例: `http://localhost:8765/`）。
+
+### 6. インライン コメント機能の案内
+
+`reviewable-html-workbench` のコメント機能が使える場合、ユーザーへ案内:
+
+```
+ブラウザでドキュメントを開いて、気になる箇所にコメントを付けられます。
+コメントは JSON に保存され、AI が次回 /build-context-site --ingest-review で取り込めます。
+```
+
+---
+
+## 出力先
+
+```
+doc/generated/context-site/
+├── index.html               ← トップページ
+├── model.json               ← reviewable-html-workbench のモデル
+├── pages/                   ← 各ドキュメントの HTML
+│   ├── requirements/
+│   ├── design/
+│   ├── adr/
+│   └── generated/
+├── assets/                  ← 図・画像
+└── comments/                ← ユーザーコメントの蓄積（あれば）
+```
+
+> ⚠️ `doc/generated/context-site/` は配布物に含めない方針が筋（毎回生成される一時成果物）。`.gitignore` への追加を推奨
+
+---
+
+## 課金前停止ポイント
+
+このスキルは**ローカル処理のみ**なので、課金発生ポイントは無い（外部 API を叩かない）。
+MCP 経由の drawio / mermaid もローカルレンダリング。
+
+---
+
+## やってはいけない
+
+- 既存 `doc/input/*` や `meta/adr-lite.md` を**書き換える**（サイト生成は read-only）
+- `history/journal.md` を**配布物として含める**（gitignore 配下のローカル閲覧用に留める）
+- 生成サイトを**外部公開**する（個人情報・契約情報が含まれる可能性、ローカルのみ）
+- reviewable-html-workbench 未 install のまま強行（手動 install を案内）
+
+---
+
+## `/auto-task` `/auto-bug` との関係
+
+- `/auto-task` `/auto-bug` の成果（PR、思考プロセス、レビュー履歴）は別途 `reviewable-html-workbench` の `render` で `doc/generated/loop-reports/` に出力される（ADR-013）
+- `/build-context-site` は**プロジェクト全体の現状**を見るためのサイト
+- 両者は独立したコマンドだが、内部で同じ `reviewable-html-workbench` を使う
+
+---
+
+## 自己評価
+- **成功自信度**: (1-10)
+- **一言理由**: {対象ドキュメントの網羅度、図のレンダリング成否、ナビの分かりやすさを踏まえて記載}

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -154,6 +154,48 @@ mkdir -p history
 
 ---
 
+### 5.6 自律ループの中断状態を拾う（Loop Engineering 連携）
+
+> 設計根拠: `meta/adr-lite.md` の **ADR-012**
+>
+> `/auto-task` `/auto-bug` 等の自律ループスキルは実行中に `history/loop-state.md` へ状態を逐次書き出している。
+> セッション終了時にこのファイルを読み、**未完了ループがあれば journal に「中断・再開ポイント」を明示**して、次セッションで `session-start` が拾えるようにする。
+
+#### 手順
+
+1. **状態ファイルの存在確認**
+   ```bash
+   [ -f history/loop-state.md ] && cat history/loop-state.md
+   ```
+
+2. **最新エントリの `status` を判定**
+   - `status: completed` → 正常終了。次の手順はスキップして良い。完了済みエントリはアーカイブ（ファイル末尾に "completed" セクションへ移動）または削除して構わない
+   - `status: in_progress` → **中断**。下記の引き継ぎ追記を行う
+   - `status: blocked_by_bug` / `blocked_by_user_confirm` → ブロック中。原因を journal へ転記
+
+3. **journal.md の「翌日への引き継ぎ」に明示**
+
+   今日のエントリの「翌日への引き継ぎ」セクションに、次の形で追加:
+
+   ```markdown
+   ### 翌日への引き継ぎ
+   - ...（既存の引き継ぎ）
+   - 🔄 **中断中の自律ループ**: `/auto-task #<issue>` （branch: `<branch>`）
+     - 最終アクション: `<last_action>`
+     - 完了済みステップ: `task-run`, `local-checks` まで
+     - 残ステップ: `basic-review` 以降
+     - **再開**: 同じ Issue 番号で `/auto-task #<issue>` を再起動するとループが続きから判定して再開
+   ```
+
+4. **状態ファイルは消さない**: 次セッションで `session-start` も拾うため、`status: completed` 以外は保持
+
+#### 注意
+
+- usage 切れ・API エラーで強制終了した場合、最終ステップが flush されていない可能性がある → `history/loop-state.md` の `last_action` と `git log` を突き合わせて実態を判断する
+- 課金前確認プロンプトで止まった場合は `status: blocked_by_user_confirm` を期待。これも引き継ぎへ記録
+
+---
+
 ### 6. 終了確認
 
 ```markdown

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 # テンプレート刷新の作業メモ（配布物には含めない）
 history/
 
+# /build-context-site の生成物（毎回再生成される一時サイト）
+doc/generated/context-site/
+
+# /auto-task /auto-bug の自律ループレポート（reviewable-html-workbench 出力）
+doc/generated/loop-reports/
+
 # 個人環境設定（音源・グローバルsettings等）。OSS公開対象外＝ローカルのみ保持
 meta/personal-env/
 

--- a/meta/adr-lite.md
+++ b/meta/adr-lite.md
@@ -205,3 +205,298 @@ ai-template 自身の skills / rules / CLAUDE.md を変更したときの「な�
 
 ### Alternatives
 - モデルごとの注意点リストを維持する案 → モデル更新のたびに陳腐化し、リスト自体が信頼できなくなる → 不採用
+
+---
+
+## ADR-008: ループエンジニアリングの全体ビジョン（5層モデル）
+
+- **日付**: 2026-06-21
+- **対象**: ai-template 全体方針（実装は ADR-009 以降で個別化）
+- **出典**: `history/journal.md` 2026-06-21 エントリ（壁打ち全体）
+
+### Context
+- 2026年6月、Loop Engineering（Addy Osmani / Boris Cherny / Peter Steinberger 発）が AI コーディング界の新トレンドに浮上
+- 進化系譜: Prompt（〜2024）→ Context（2025）→ Harness（2026初頭）→ **Loop（2026.6〜）**
+- このリポは Context 層（CLAUDE.md/rdd.md 等）と Harness 層（44スキル+rules+hooks）は厚いが、**Loop 層が薄い**
+- 6/15 に `self-driving-loop` スキルを「重い」と削除した経緯がある → 同じ轍を避ける必要
+- ユーザー直観: 「1スラッシュコマンドでユースケース実行」型（=Inner Loop）に振りたい。Outer Loop（cron的）は最小限
+
+### Decision
+ループエンジニアリング取り込みを **5層モデル**で整理し、今回スコープを **L1部分+L2+L4+L5** に絞る:
+
+| L | 役割 | 今回スコープ |
+|---|---|---|
+| L1 | 思考の場（要件・設計の HTML 化サイト） | ✅ 既存全 doc を HTML 化（要件・デザイン・ADR含む全コンテキスト閲覧） |
+| L2 | 自律実装ループ（task/bug の親ループ） | ✅ `/auto-task` `/auto-bug` 新設（ADR-009） |
+| L3 | 1ユースケース処理（人間フィードバック後の修正等） | ❌ 既存スキルで代替、今回は外す |
+| L4 | 観測・記録（PR/思考プロセスの HTML 残し） | ✅ `reviewable-html-workbench` プラグイン統合（後半 ADR） |
+| L5 | ガードレール（usage 切れ・課金前停止） | ✅ 自動停止 + 未完了記録（後半 ADR） |
+
+**設計原則**:
+- **Inner Loop 優先**: 1コマンドで完結する親ループを設計。Outer Loop（時間駆動 cron）は採用しない
+- **既存スキルは触らない**: 親ループは既存スキル（task-run / bug-fix / basic-review / deep-review 等）を**連鎖呼び出し**するだけ。Harness 層と Loop 層を分離
+- **モデル非依存（ADR-007 継承）**: 親ループは手続きで賢さを補う。特定モデル前提にしない
+
+### Consequences
+- (+) 既存 Harness 層（44スキル）を再利用できる。実装コスト軽め
+- (+) Inner Loop なので「重くて使われない」失敗（6/15 self-driving-loop 削除の教訓）を避けられる
+- (+) ループエンジニアリングのトレンドを取り込みつつ、このリポの「人間 on the Loop」思想と整合
+- (−) Outer Loop（夜中走らせ）は今回入らない。後で必要なら追加
+- (−) L3 を外したため、人間フィードバック後の修正は既存スキル（pr-respond / task-run 等）を手動で呼ぶ運用が続く
+
+### Alternatives
+- **全層一気に実装**: 数週間〜数ヶ月仕事。6/15 の失敗（重さで死蔵）を繰り返すリスク → 段階導入を採用
+- **Outer Loop 採用**（`/loop 30m /auto-task` 等）: 派手だが運用が重い・トークン消費激しい・誤発火怖い。このリポの性格に合わない → Inner Loop に絞る
+- **スキル復活（旧 self-driving-loop 再導入）**: 6/15 削除の教訓を尊重。スキルでなく**親コマンド**として実装 → スキル復活は不採用
+
+---
+
+## ADR-009: 自律実装ループ `/auto-task` `/auto-bug`（L2）
+
+- **日付**: 2026-06-21
+- **対象**: `.claude/commands/auto-task.md`（新規）, `.claude/commands/auto-bug.md`（新規）
+- **出典**: ADR-008 全体ビジョン
+
+### Context
+- L2「自律実装ループ」の具体実装
+- 既存スキル群が **Inner Loop の素材**として揃っている: `task-run` / `bug-investigate` / `bug-propose` / `bug-fix` / `basic-review` / `deep-review` / `pr-respond` 等
+- 必要なのは**これらを連鎖する親コマンド**
+- ユーザー要件: task 実行中に bug 検知したら自律的に bug 処理へフォールバック
+
+### Decision
+**2つの親コマンドを新設**:
+
+**`/auto-task <issue#>`** — task 自律処理:
+```
+1. task-run（実装）
+2. ローカル lint + typecheck
+3. テスト実行
+   └─ 失敗/不整合検知 → 内部で bug-* スキル連鎖発動
+        ├─ bug-investigate
+        ├─ bug-propose
+        └─ bug-fix
+4. basic-review 反復（致命指摘0まで）
+5. deep-review 反復（全指摘0まで）
+6. PR 作成（gh CLI）
+7. ラベル付与 `ai-merged-unreviewed`（ADR-010）
+8. task → sprint へ自律マージ（ADR-010）
+```
+
+**`/auto-bug <issue#>`** — bug 単独処理:
+```
+1. bug-investigate
+2. bug-propose
+3. bug-fix
+4. テスト確認
+5. /auto-task と同じ後半（review→PR→label→merge）
+```
+
+**設計のキモ**:
+- `/auto-task` が `/auto-bug` を**コマンドとして呼ぶ**のではなく、内部で**bug-* スキルを連鎖呼び出し**する（同一セッション内での処理）
+- `/auto-bug` は人間が単独でも呼べる独立コマンドとして両立
+- どちらも既存スキルを**そのまま再利用**。スキル本体は触らない
+- 親コマンドは Markdown プロンプトファイル（`.claude/commands/*.md`）として実装。Boris Cherny / Anthropic 公式と同じ流儀
+
+### Consequences
+- (+) 既存 44 スキルを壊さず、新規ファイル 2 本（`auto-task.md`, `auto-bug.md`）で L2 が完成
+- (+) Inner Loop なので 1 起動で完結。usage 消費が予測しやすい
+- (+) bug 検知時のフォールバックが組み込まれているため、テスト失敗で止まらず自走する
+- (−) `/auto-task` の中身（Markdown プロンプト）の品質がループ全体の品質を決める → 初版から完璧は無理、運用しながら磨く
+- (−) スキル連鎖の途中で詰まった場合、どこで止まったか追跡が必要（→ ADR-012 で session-end が未完了箇所を記録する）
+
+### Alternatives
+- **Stop Hook で再投入する Ralph Loop パターン**: Anthropic 公式の Ralph Wiggum と同じ流儀。完了文字列まで強制反復。L3 まで含むなら有力だが、L2 だけなら親コマンドの方が読みやすい → 採用見送り（将来必要なら追加）
+- **Workflow スクリプト（多エージェント敵対的検証）**: Boris の `/batch` 的なパターン。トークン消費が重い。L2 の標準動作には過剰 → 採用見送り（深い review 等の限定用途で将来）
+- **スキル本体を改造して連鎖呼び出しを内蔵**: スキルの責務が肥大化し再利用性が落ちる → 親コマンド側で連鎖する分離設計を採用
+
+---
+
+## ADR-010: マージ戦略（ラベル運用パターン、AI 自律マージ）
+
+- **日付**: 2026-06-21
+- **対象**: ADR-009 の親コマンド内動作（gh CLI のラベル運用）, `git.md` は無改訂
+
+### Context
+- ADR-009 で AI が自律マージする設計を採用 → どのブランチまで AI 自律で、どこから人間レビューか の線引きが必要
+- 既存 `git.md`: `task/* → sprint/* → main` の3層。sprint→main は CI＋人間レビュー必須
+- ユーザー懸念: 人間目視前に main へ入る事故を防ぎたい
+- 検討した選択肢:
+  - A: 現状ブランチ構造 + ラベル運用
+  - B: `task/* → ai-sprint/* → sprint/* → main` の4層化
+  - C: スプリント PR は人間トリガーのみ
+
+### Decision
+**選択肢 A 採用**: 現状ブランチ構造維持 + ラベル運用
+
+**ルール**:
+- `task/*` → `sprint/*`: **AI 自律マージ可**。PR 作成時に `ai-merged-unreviewed` ラベルを付与
+- `sprint/*` → `main`: **人間レビュー＆マージ必須**（git.md の既存ルールそのまま）
+- ユーザーが PR を目視確認したら、ラベル `ai-merged-unreviewed` を手動で外す（or 将来 `/reviewed` コマンドで自動外し）
+- 未レビュー PR の一覧は `gh pr list --label ai-merged-unreviewed` で取得可能
+
+**git.md は無改訂**: ブランチ構造は変えない。AI 自律マージはあくまで `task/* → sprint/*` の範囲内で、既存ルールと整合する
+
+### Consequences
+- (+) `git.md` 既存ルールを破らずに AI 自律マージが組み込める
+- (+) ラベルだけで「人間未確認」を可視化できる。GitHub 標準機能のみで完結
+- (+) sprint→main は人間がレビューする原則が守られるため、本番影響を伴うマージは必ず人手を経る
+- (+) sprint 単位で「AI が組み立てた中身」を人間が一括レビューできる（task ごとにレビュー強制よりも軽い）
+- (−) `sprint/*` 内に「AI 統合済み・未レビュー」と「人間確認済み」が混在する状態が発生する（ラベルで区別）
+- (−) ラベル付与・剥がしのオペレーションがユーザー側で必要（最初は手動、将来コマンド化）
+
+### Alternatives
+- **B: 4層化（`task/* → ai-sprint/* → sprint/* → main`）**: 物理的に AI/人間ラインが分離して安心感あり。ただし git.md 改訂が必要、ブランチ階層が深くなり promote 作業が増える。運用負荷が上回る → 不採用
+- **C: スプリント PR は人間トリガー**: AI 自律マージの旨みが減る。task→sprint の大量マージ後に sprint→main の差分が膨らみレビュー負荷が逆に増える → 不採用
+- **task→sprint も人間マージ**: AI 自律ループの価値を消す。L2 採用の動機と矛盾 → 不採用
+
+---
+
+## ADR-011: 全コンテキスト HTML サイト（L1 部分採用）
+
+- **日付**: 2026-06-21
+- **対象**: 新規スラッシュコマンド `/build-context-site`（仮）, 既存 `design-html` skill との関係整理
+- **出典**: ADR-008、ユーザー要件「ここ見れば人間も全コンテキスト分かるよ」的なローカル HTML サイト
+
+### Context
+- L1（思考の場）のうち、**HTML 設計書サイト**だけを部分採用する
+- ユーザー要件: 既存 design ドキュメントが Markdown 中心で、HTML 化されていない → **ローカルで閲覧できる HTML サイト**として全コンテキストを横断できる場が欲しい
+- 既存資産:
+  - `design-html` skill: Markdown/JSON から HTML を生成
+  - `design-mock` / `design-ssot` / `design-ui` skill: デザイン段階の HTML 生成
+  - `reviewable-html-workbench` プラグイン（ADR-013 で統合）: HTML レンダリング機能あり
+- 「全コンテキスト」の範囲: `doc/input/*` + `doc/generated/*` + `meta/adr-lite.md` + 関連 `history/*`（gitignore 配下なのでローカルのみ）
+
+### Decision
+**全コンテキスト HTML サイトを生成する親コマンドを新設**:
+
+**`/build-context-site`**（仮称）の動作:
+1. 対象ドキュメントを収集:
+   - `doc/input/*.md`（要件定義、デザイン SSOT 等）
+   - `doc/generated/*`（マニュアル、設計書）
+   - `meta/adr-lite.md`（設計決定ログ）
+   - `history/journal.md` の最新N日分（ローカル閲覧用、配布物には含まない）
+2. **MCP の drawio / mermaid で図を埋め込む**（要件・設計の構造可視化）
+3. `reviewable-html-workbench` の `render` を使って HTML バンドル生成
+4. ローカルプレビューサーバを起動 → ブラウザで `/index.html` を開く
+5. ナビゲーションは「ファイル一覧 + 横断検索」で全文を渡り歩ける形
+
+**生成物の置き場**: `doc/generated/context-site/`（配布対象外）
+
+**既存スキルとの関係**:
+- `design-html` / `design-mock` / `design-ui` / `design-ssot` は**デザイン領域の HTML 生成**を担当（既存責務維持）
+- `/build-context-site` は**横断的にサイト化する親コマンド**として上位レイヤで動く。スキルは触らない
+
+### Consequences
+- (+) 人間が「このプロジェクトの全前提」をブラウザ1つで把握できる → 引き継ぎ・確認コスト激減
+- (+) AI も同じサイトを参照対象にできる（Context 層の補強）
+- (+) drawio/mermaid 図を埋め込むことで Markdown だけより構造理解が早い
+- (+) `reviewable-html-workbench` のレンダリング基盤を再利用 → 実装軽量
+- (−) サイト生成のたびに各ドキュメントの最新状態を再収集する必要（手動更新 or watch モードは後で検討）
+- (−) `history/` は gitignore 配下のためチーム共有不可。ローカル閲覧専用と割り切る
+
+### Alternatives
+- **既存 `design-html` skill を拡張して全コンテキスト化**: スキル責務が「デザイン」から「全ドキュメント」に肥大化 → スキル分離原則違反。新規親コマンドを採用
+- **静的サイトジェネレータ（Docusaurus 等）導入**: 学習コスト・依存追加が重い。既存 `reviewable-html-workbench` で足りる範囲 → 採用見送り
+- **doc/input を直接 HTML で書く**: Markdown 編集の手軽さを失う。Markdown→HTML 変換を採用
+
+---
+
+## ADR-012: ガードレール（usage 自動停止 + 未完了記録）
+
+- **日付**: 2026-06-21
+- **対象**: `session-end` skill 拡張, 親コマンド（ADR-009）内の課金前確認プロンプト
+- **出典**: ADR-008 L5、ユーザー要件「クレジット切れたら止まる」「できてないとこ判断して session-end に残す」
+
+### Context
+- 自律ループ（ADR-009）が暴走すると課金事故になる → ガードレールが必要
+- ただしユーザー要件は**最小限**:
+  - usage 切れの**自動検知＆復活再開は不要**（Claude が API エラーで勝手に止まるのに任せる）
+  - 課金発生ポイント（外部 API 呼び出し等）は**事前に止める**
+  - **未完了箇所を session-end に記録**して、次セッションで再開できるように
+- L5 を「過剰に作り込まない」のが方針（重さで死蔵を避ける ADR-008 の精神を継承）
+
+### Decision
+**ガードレールを3点に絞る**:
+
+1. **usage 切れは自動停止に任せる**
+   - Anthropic API のレート/クレジット切れは Claude セッションが自然停止する → 明示的な検知ロジックは作らない
+   - 親コマンド側で「停止検知」のための polling 等は不要
+
+2. **課金発生ポイントは確認プロンプトで止める**
+   - 親コマンド内（ADR-009 の `/auto-task` / `/auto-bug`）で以下の操作直前に **人間確認を挟む**:
+     - 新規パッケージインストール（`npm install` 等で従量課金 SaaS が絡む場合）
+     - リモートデプロイ（本番影響）
+     - 外部 API 呼び出し（OpenAI/Anthropic 以外の従量課金サービス）
+     - GitHub Actions の有料ランナー起動（今回は CI 保留のため発火想定なし）
+   - ローカルツール（gh CLI / git / lint / typecheck / test）は課金ゼロなので**確認不要**
+
+3. **未完了箇所を session-end が記録**
+   - `session-end` skill を拡張: セッション終了時に「自律ループが途中で止まったか」を判定
+   - 判定ロジック: `/auto-task` `/auto-bug` の進行状態（実装中／レビュー中／PR 作成中／マージ前 等）を**状態ファイル**（`history/loop-state.md`、gitignore）に逐次書く設計
+   - `session-end` が状態ファイルを読んで「未完了の場合は journal に「中断・再開ポイント」を明示」する
+   - 次セッションで `session-start` がこれを拾って続きから再開できる
+
+**状態ファイル**: `history/loop-state.md`
+- 親コマンド開始時に新規作成
+- 各ステップ完了時に追記
+- 完了時にクリアまたはアーカイブ
+
+### Consequences
+- (+) 過剰実装を避けつつ、最低限の安全網が機能する
+- (+) usage 切れの「復活検知＆再開」を作らないことで実装コストが激減（ユーザー方針）
+- (+) 未完了箇所が journal に残るため、次セッションでコンテキストロスなく再開できる
+- (+) 課金前停止は親コマンドの prompt に書くだけで実現できる（hook 不要）
+- (−) usage 切れの瞬間に状態ファイルが書き終わってない可能性（最終状態を毎ステップ flush することで緩和）
+- (−) 「課金発生ポイント」の網羅性は親コマンド作成者の判断に依存（運用しながらリスト拡充）
+
+### Alternatives
+- **usage 監視を polling で実装**: API コール費用が増える＋運用が重い。ユーザー却下 → 不採用
+- **すべての破壊的操作で確認プロンプト**: 確認の嵐になり自律ループの旨みが消える → 課金ポイントに絞る
+- **状態ファイルを JSON にする**: 機械可読性は上がるが、人間が journal と並べて読む時 Markdown が楽 → Markdown 採用
+
+---
+
+## ADR-013: `reviewable-html-workbench` 統合（L4 観測・記録）
+
+- **日付**: 2026-06-21
+- **対象**: 新規依存（外部プラグイン）, `/auto-task` `/auto-bug` の出力フェーズ拡張
+- **出典**: ADR-008 L4、ユーザー指定リポ `u-ichi/reviewable-html-workbench`
+
+### Context
+- L4「観測・記録」: AI の PR・思考プロセス・成果物を **HTML で残し、人間が後追いレビュー可能**にする
+- `reviewable-html-workbench`（ユーザー自作の Claude Code プラグイン）が**まさにこの用途**: HTML バンドル生成 + ブラウザ上でインライン コメント + AI がコメントを読み取り更新
+- 機能: skills（`visual-html-renderer`, `reviewable-design-doc`, `plan-preview`）+ CLI（`render`, `ingest-review`, `watch-comments` 等）
+- インストール: `claude plugin marketplace add u-ichi/reviewable-html-workbench` → `claude plugin install reviewable-html-workbench`
+
+### Decision
+**`reviewable-html-workbench` を依存として組み込み、2用途で活用**:
+
+**用途1: 設計段階のレビュー**（L1 と連動）
+- `/build-context-site`（ADR-011）が生成する HTML を `reviewable-html-workbench` 経由で出力
+- 人間がブラウザでコメント → AI が `ingest-review` で読み取り → 設計を更新
+
+**用途2: 自律ループの成果残し**（L4 本体）
+- `/auto-task` / `/auto-bug`（ADR-009）の最終ステップで、以下を HTML バンドル化:
+  - **PR の中身**（diff、コミットメッセージ、関連 issue リンク）
+  - **思考プロセスログ**（task-run / bug-investigate / レビューループの判断履歴）
+  - **テスト結果・review 指摘の収束履歴**
+- 出力先: `doc/generated/loop-reports/<timestamp>-<task-id>/`
+- ローカルプレビューサーバで閲覧可能 → 人間が後から流し読み＆コメント可能
+- コメントが付いたら、次の `/auto-task` 起動時に AI が拾って改善ループへフィードバック
+
+**統合の最小範囲**:
+- プラグインは**依存として install するだけ**。本体は触らない
+- ai-template 側では `/auto-task` の最終ステップに「`reviewable-html-workbench` の `render` 呼び出し」を追加するだけで完了
+
+### Consequences
+- (+) AI の作業履歴が**ブラウザで人間レビュー可能な形**で残る → blind merge 防止の Vibe Coding ループ（dev-practices.md）と完全整合
+- (+) `reviewable-html-workbench` がユーザー自作で**よく分かっている依存**（外部リスクが小さい）
+- (+) コメント → AI 取り込みの双方向フィードバックが動く → self-improving メモリ的に効く
+- (+) L1（設計段階）と L4（実装後）の両方で同じ仕組みを再利用できる
+- (−) 外部プラグイン依存が1つ増える（更新の追従が必要）
+- (−) `reviewable-html-workbench` 本体に問題があった場合、ai-template 側で完全には吸収できない（軽い結合に留めることで緩和）
+
+### Alternatives
+- **HTML 出力を自前実装**: 車輪の再発明。`reviewable-html-workbench` がインライン コメント機能を含んで揃っている → 自前不採用
+- **GitHub PR ページのみで完結**: PR コメントだけだと思考プロセス・テスト履歴等を整理して残しにくい。HTML バンドルの方が情報密度が高い → PR + HTML の併用採用
+- **Notion/Confluence 等の外部サービス**: クラウド依存が増える、課金リスク、ユーザー方針（ローカル閲覧優先）と矛盾 → 不採用


### PR DESCRIPTION
## Summary
- Loop Engineering（2026.6〜）の取り込み方針を ADR 6本で確定し、Inner Loop の親スキル3本を新設
- 既存44スキル（Harness 層）は不可侵。親スキルは既存スキルを**連鎖呼び出し**するだけ
- 5層モデル（L1〜L5）のうち **L1部分 + L2 + L4 + L5** を採用、L3 は既存スキルで代替

## 設計決定（meta/adr-lite.md）
| ADR | 内容 |
|---|---|
| 008 | 全体ビジョン（5層モデル、スコープ確定、Inner Loop 優先） |
| 009 | `/auto-task` `/auto-bug` 親スキル設計（bug-* 連鎖フォールバック） |
| 010 | マージ戦略A（`ai-merged-unreviewed` ラベル運用、git.md 無改訂） |
| 011 | `/build-context-site`（全コンテキスト HTML サイト） |
| 012 | ガードレール（usage 切れ自動停止 + loop-state.md + session-end 拡張） |
| 013 | `reviewable-html-workbench` 統合（設計レビュー + 自律ループ成果残し） |

## 実装
- **新規**: `.claude/skills/auto-task/SKILL.md`（実装→テスト→bug連鎖→review反復→PR→ラベル→自律マージ）
- **新規**: `.claude/skills/auto-bug/SKILL.md`（investigate→propose→fix→効果検証→以降auto-taskと同じ）
- **新規**: `.claude/skills/build-context-site/SKILL.md`（reviewable-html-workbench 利用、MCP drawio/mermaid 図埋め込み）
- **編集**: `.claude/skills/session-end/SKILL.md` に section 5.6（`history/loop-state.md` 取り込み）
- **編集**: `.gitignore` に `doc/generated/context-site/` `loop-reports/` 追加

## 設計原則
- **Inner Loop 優先**: 1コマンドで完結する親スキル。Outer Loop（cron的）は採用しない
- **既存スキル不可侵**: Harness 層と Loop 層を分離
- **モデル非依存**（ADR-007 継承）

## Test plan
- [ ] `/auto-task <issue>` でドライラン（小さい task で挙動確認）
- [ ] `/auto-bug <issue>` でドライラン
- [ ] `ai-merged-unreviewed` ラベルの自動作成と付与の確認
- [ ] usage 切れ時の `history/loop-state.md` 残存確認
- [ ] `/build-context-site` のサイト生成確認（reviewable-html-workbench install 済）
- [ ] session-end が中断状態を journal に反映するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzUy3pX8ZLrH683pNQ3o37